### PR TITLE
Update and refine GitHub actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,12 +20,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: 'Set up JDK ${{ matrix.java }}'
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
+          distribution: zulu
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
       - name: Build and test using Gradle
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: build
+        run: ./gradlew build


### PR DESCRIPTION
Use newer releases of the GitHub checkout and Java setup actions.  Use Gradle's official setup action.